### PR TITLE
enable windows builds azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,9 +4,8 @@ strategy:
       imageName: 'ubuntu-16.04'
     mac:
       imageName: 'macos-10.13'
-    # Windows builds don't work at the moment
-    # windows:
-    #  imageName: 'windows-2019'
+    windows:
+      imageName: 'windows-2019'
 
 pool:
   vmImage: $(imageName)


### PR DESCRIPTION
tests failing on windows because `./packages/cli/lib/commands/alfred.js` shebang causes syntax errors. Not the case for other OS's.