### PR TITLE
enable e2e tests on ci

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,7 @@
     "packages/*",
     "packages/cli/test/e2e/tmp/*",
     "tests/fixtures/*",
+    "tests/fixtures",
     "website"
   ],
   "version": "0.0.2-alpha.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn test && cross-env ALFRED_E2E_TEST=true jest tests/fixtures/fixtures.spec.js"
+      "pre-commit": "yarn test"
     }
   },
   "keywords": [
@@ -57,6 +57,7 @@
     "packages/*",
     "packages/cli/test/e2e/tmp/*",
     "tests/fixtures/*",
+    "tests/fixtures",
     "website"
   ],
   "devDependencies": {


### PR DESCRIPTION
tests failing because of unexpected behavior involved with resolving port and url for e2e tests