### PR TITLE
Close #335 by fixing typos and removing instances of passive voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See our [examples directory](https://github.com/amilajack/alfred/tree/master/exa
 
 |     | Example                                 | Descrption                              |
 |-----|-----------------------------------------|-----------------------------------------|
-| 1.  | [hello world node][hello-world-example] | A simple hello work app in node         |
+| 1.  | [hello world node][hello-world-example] | A simple hello world app in node         |
 | 2.  | [react library][react-lib-example]      | A small button library built with React |
 | 3.  | typescript react app                    | ❌                                      |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 |     | Example | Descrption |
 | --- | ---     | ---        |
-| 1.|  [hello world](https://github.com/amilajack/alfred/tree/master/examples/hello-world) | A simple hello work app in node |
+| 1.|  [hello world](https://github.com/amilajack/alfred/tree/master/examples/hello-world) | A simple hello world app in node |
 | 2.|  [react](https://github.com/amilajack/alfred/tree/master/examples/react) | An Alfred react app |
 | 3.|  [redux](https://github.com/amilajack/alfred/tree/master/examples/redux) | A simple counter app built with redux |
 | 4.|  [typescript](https://github.com/amilajack/alfred/tree/master/examples/typescript) | **HELP WANTED** |

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -68,7 +68,7 @@ Suppose your Alfred project has the following config:
 }
 ```
 
-Creating a shareable config will extract this config to an Alfred config. In this case, it makes sense to call the config `alfred-config-web-app`.
+Creating a shareable config will extract this config into an Alfred config. In this case, it makes sense to call the config `alfred-config-web-app`.
 
 ```jsonc
 // alfred-config-web-app/package.json

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -45,7 +45,7 @@ Decide whether to install dependencies with NPM or Yarn
 
 Default: `.`
 
-The directory, relative to the project directory, to write config files
+The path (relative to project directory) that config files are written to
 
 ## Extending Alfred Configs
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -15,7 +15,7 @@ title: Configuration
     "skills": [
       "@alfred/skill-react"
     ],
-    // Determine to install with NPM or Yarn
+    // Determine npm client (NPM or Yarn)
     "npmClient": "yarn"
   }
 }
@@ -27,7 +27,7 @@ title: Configuration
 
 Default: `undefined`
 
-The name of the config which you want to extend
+The name of the config that you want to extend
 
 ### `skills`
 
@@ -39,19 +39,19 @@ The skills that the Alfred project is using
 
 Default: `npm`
 
-Determine to install dependencies with NPM or Yarn
+Decide whether to install dependencies with NPM or Yarn
 
 ### `configsDir`
 
 Default: `.`
 
-The directory, relative to the project directory, which config files should be written to
+The directory, relative to the project directory, to write config files
 
 ## Extending Alfred Configs
 
 Alfred allows you to create reusable configs. This is useful when you want to share the same config across multiple projects.
 
-Here is an example of how you would ues a sharable config.
+Here is an example of how you would use a shareable config.
 
 Suppose your Alfred project has the following config:
 
@@ -68,7 +68,7 @@ Suppose your Alfred project has the following config:
 }
 ```
 
-This config can be extracted to an Alfred config by creating a sharable config. In this case, it makes sense to call the config `alfred-config-web-app`.
+Creating a shareable config will extract this config to an Alfred config. In this case, it makes sense to call the config `alfred-config-web-app`.
 
 ```jsonc
 // alfred-config-web-app/package.json


### PR DESCRIPTION
This pull request seeks to close #335 by changing "hello work" to "hello world" in [the "Examples" section of `README.md`](https://github.com/amilajack/alfred/blob/master/README.md#examples) and [`examples/README.md`](https://github.com/amilajack/alfred/blob/master/examples/README.md), and changing a few typos and a couple of instances of the passive voice in [`website/docs/configuration.md`](https://github.com/amilajack/alfred/blob/master/website/docs/configuration.md), as mentioned in [the "Guidelines for Writing Docs" section in `CONTRIBUTING.md`](https://github.com/amilajack/alfred/blob/master/CONTRIBUTING.md#guidelines-for-writing-docs).